### PR TITLE
Fix some issues loading readwise data on first auth

### DIFF
--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,14 +1,16 @@
 import React, { FC } from 'react';
 
-const TextInput: FC<{
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
-  value: string;
-  name: string;
-  placeholder: string;
-  label: string;
-  type: React.HTMLInputTypeAttribute;
-}> = ({ onChange, onBlur, value, placeholder, name, label }) => {
+const TextInput: FC<
+  React.InputHTMLAttributes<HTMLInputElement> & {
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+    value: string;
+    name: string;
+    placeholder: string;
+    label: string;
+    type: React.HTMLInputTypeAttribute;
+  }
+> = ({ onChange, onBlur, value, placeholder, name, label, ...props }) => {
   return (
     <div className="flex flex-col space-y-1">
       <label
@@ -25,6 +27,7 @@ const TextInput: FC<{
         value={value}
         className="h-10 border-moss border rounded-md text-sm px-2 outline-none focus:outline-moss"
         placeholder={placeholder}
+        {...props}
       />
     </div>
   );

--- a/src/lib/readwise/index.ts
+++ b/src/lib/readwise/index.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useLocalstorage } from 'rooks';
 import useSWR from 'swr';
+
 import { Book, Highlight, RawBook, RawHighlight } from './types';
 
 interface FetchBookmarksRequest {
@@ -97,17 +98,13 @@ export function useHighlights() {
 
   const { id } = useParams();
 
-  const { data, error, isValidating } = useSWR<Array<Highlight>, any>(
-    'v2/highlights',
-    () => fetchHighlights({ id, token: token as string })
+  const { data, error, isValidating } = useSWR('v2/highlights', () =>
+    fetchHighlights({ id, token: token as string })
   );
 
   useEffect(() => {
     if (error) {
-      if (
-        error.response.statusCode === 401 ||
-        error.response.statusCode === 403
-      ) {
+      if (error.status === 401 || error.status === 403) {
         console.log('Invalid Credentials');
       } else {
         throw error;
@@ -156,20 +153,16 @@ export async function fetchBooks({
   return books.sort((a, b) => b.num_highlights - a.num_highlights);
 }
 
-export function useBooks() {
-  const { value: token } = useLocalstorage('g:readwise_token');
+export function useBooks(token: string) {
+  // const { value: token } = useLocalstorage('g:readwise_token');
 
-  const { data, error, isValidating } = useSWR<Array<Book>, any>(
-    'v2/books',
-    () => fetchBooks({ token: token as string })
+  const { data, error, isValidating } = useSWR('v2/books', () =>
+    fetchBooks({ token: token })
   );
 
   useEffect(() => {
     if (error) {
-      if (
-        error.response.statusCode === 401 ||
-        error.response.statusCode === 403
-      ) {
+      if (error.status === 401 || error.status === 403) {
         console.error('Invalid Credentials');
       } else {
         throw error;
@@ -180,6 +173,7 @@ export function useBooks() {
   return {
     books: data || [],
     loading: (!data && !error) || isValidating,
+    error: error,
   };
 }
 

--- a/src/views/Library.tsx
+++ b/src/views/Library.tsx
@@ -7,9 +7,12 @@ import { Callout } from '../components/Callout';
 import TextInput from '../components/TextInput';
 
 function Readwise() {
-  const [token, setToken] = useLocalstorageState('g:readwise_token', null);
+  const [token, setToken] = useLocalstorageState<string>(
+    'g:readwise_token',
+    null
+  );
 
-  return token == null ? (
+  return !token ? (
     <div>
       <Callout title="Readwise Library">
         Enter your Readwise access token, which you can access{' '}
@@ -49,6 +52,8 @@ function Readwise() {
               onBlur={handleBlur}
               type="text"
               name="token"
+              required
+              minLength={1}
               onChange={handleChange}
               value={values.token}
               label="Readwise Access Token"


### PR DESCRIPTION
### Description

- Fixes a bug where the readwise token from localstorage was inaccessible by readwise hooks after form submission. Rather than retrieve the token from localstorage, instead it is now passed directly as an argument to the `useBooks()` hook.

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

Fix bugz

### How Has This Been Tested?

barely lol

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
